### PR TITLE
Fix FRCdelegate issue where invalid type is passed

### DIFF
--- a/CoreStore/Internal/FetchedResultsControllerDelegate.swift
+++ b/CoreStore/Internal/FetchedResultsControllerDelegate.swift
@@ -82,6 +82,13 @@ internal final class FetchedResultsControllerDelegate: NSObject, NSFetchedResult
     
     @objc dynamic func controller(controller: NSFetchedResultsController, didChangeObject anObject: AnyObject, atIndexPath indexPath: NSIndexPath?, forChangeType type: NSFetchedResultsChangeType, newIndexPath: NSIndexPath?) {
         
+        // This fix is for a bug where Apple passes 0 for NSFetchedResultsChangeType, but this is not a valid enum case.
+        // Swift will then always execute the first case of the switch causing strange behaviour.
+        // https://forums.developer.apple.com/thread/12184#31850
+        if type.rawValue == 0 {
+            return
+        }
+        
         // This whole dance is a workaround for a nasty bug introduced in XCode 7 targeted at iOS 8 devices
         // http://stackoverflow.com/questions/31383760/ios-9-attempt-to-delete-and-reload-the-same-index-path/31384014#31384014
         // https://forums.developer.apple.com/message/9998#9998


### PR DESCRIPTION
See also https://forums.developer.apple.com/thread/12184#31850

In my project `NSFetchedResultsController` starts throwing us `NSFetchedResultsChangeType`s that are of value `0`. This is not a valid value, if you switch over `type` when this occurs the first case is executed. Causing strange behavior and fatal application errors.

The current "dance" to avoid FRC issues is not enough, I'm affraid we have to add this extra check to avoid these issues.