### PR TITLE
Fixes #98 (deadlock when merge happens while main queue is querying)

### DIFF
--- a/CoreStore.xcodeproj/project.xcworkspace/xcshareddata/CoreStore.xcscmblueprint
+++ b/CoreStore.xcodeproj/project.xcworkspace/xcshareddata/CoreStore.xcscmblueprint
@@ -10,10 +10,10 @@
   "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "F347F55F-7F5C-4476-9148-6E902F06E4AD",
   "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
     "8B2E522D57154DFA93A06982C36315ECBEA4FA97" : "CoreStoreLibraries\/GCDKit",
-    "4B60F1BCB491FF717C56441AE7783C74F417BE48" : "CoreStore"
+    "4B60F1BCB491FF717C56441AE7783C74F417BE48" : "CoreStore\/"
   },
   "DVTSourceControlWorkspaceBlueprintNameKey" : "CoreStore",
-  "DVTSourceControlWorkspaceBlueprintVersion" : 203,
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
   "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "CoreStore.xcodeproj",
   "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
     {

--- a/Sources/Internal/NSManagedObjectContext+Transaction.swift
+++ b/Sources/Internal/NSManagedObjectContext+Transaction.swift
@@ -101,8 +101,8 @@ internal extension NSManagedObjectContext {
     }
     
     @nonobjc
-    internal func saveSynchronously() -> SaveResult {
-        
+    internal func saveSynchronously(mergeSynchronously: Bool = true) -> SaveResult {
+      
         var result = SaveResult(hasChanges: false)
         
         self.performBlockAndWait {
@@ -114,7 +114,7 @@ internal extension NSManagedObjectContext {
             
             do {
                 
-                self.isSavingSynchronously = true
+                self.isSavingSynchronously = mergeSynchronously
                 try self.save()
                 self.isSavingSynchronously = nil
             }
@@ -131,7 +131,7 @@ internal extension NSManagedObjectContext {
             
             if let parentContext = self.parentContext where self.shouldCascadeSavesToParent {
                 
-                switch parentContext.saveSynchronously() {
+                switch parentContext.saveSynchronously(mergeSynchronously) {
                     
                 case .Success:
                     result = SaveResult(hasChanges: true)


### PR DESCRIPTION
Feel free to let me know if you want to accomplish this differently. 

Not quite sure how you want to approach tests for this, given that the only way (I can think of) to test the negative case is to intentionally create a deadlock in tests...