### PR TITLE
Add an override to cs_typeName which deals with String explicitly.

### DIFF
--- a/Sources/Internal/Functions.swift
+++ b/Sources/Internal/Functions.swift
@@ -86,3 +86,8 @@ internal func cs_typeName(_ name: String?) -> String {
     
     return "<\(name ?? "unknown")>"
 }
+
+internal func cs_typeName(_ name: String) -> String {
+
+    return "<\(name)>"
+}


### PR DESCRIPTION
Fix for issue #138 - all the tests pass, but I don't know if I've missed something subtle this method does in other cases in the library. I don't _think_ so . . . 