### PR TITLE
[Importing] Convert `shouldUpdate(from:in:)` method to an instance method.

### DIFF
--- a/Sources/Importing/BaseDataTransaction+Importing.swift
+++ b/Sources/Importing/BaseDataTransaction+Importing.swift
@@ -154,7 +154,7 @@ public extension BaseDataTransaction {
                 
                 if let object = self.fetchOne(From(entityType), Where(uniqueIDKeyPath, isEqualTo: uniqueIDValue)) {
                     
-                    guard entityType.shouldUpdate(from: source, in: self) else {
+                    guard object.shouldUpdate(from: source, in: self) else {
                         
                         return nil
                     }
@@ -231,7 +231,7 @@ public extension BaseDataTransaction {
                     try autoreleasepool {
 
                         if let object = existingObjectsByID[objectID] {
-                            guard entityType.shouldUpdate(from: source, in: self) else { return }
+                            guard object.shouldUpdate(from: source, in: self) else { return }
 
                             try object.update(from: source, in: self)
                             result.append(object)

--- a/Sources/Importing/ImportableUniqueObject.swift
+++ b/Sources/Importing/ImportableUniqueObject.swift
@@ -72,7 +72,7 @@ public protocol ImportableUniqueObject: ImportableObject {
     var uniqueIDValue: UniqueIDType { get set }
     
     /**
-     Return `true` if an object should be created from `source`. Return `false` to ignore and skip `source`. The default implementation returns the value returned by the `shouldUpdate(from:in:)` implementation.
+     Return `true` if an object should be created from `source`. Return `false` to ignore and skip `source`. The default implementation returns `true`.
      
      - parameter source: the object to import from
      - parameter transaction: the transaction that invoked the import. Use the transaction to fetch or create related objects if needed.
@@ -87,7 +87,7 @@ public protocol ImportableUniqueObject: ImportableObject {
      - parameter transaction: the transaction that invoked the import. Use the transaction to fetch or create related objects if needed.
      - returns: `true` if an object should be updated from `source`. Return `false` to ignore.
      */
-    static func shouldUpdate(from source: ImportSource, in transaction: BaseDataTransaction) -> Bool
+    func shouldUpdate(from source: ImportSource, in transaction: BaseDataTransaction) -> Bool
     
     /**
      Return the unique ID as extracted from `source`. This method is called before `shouldInsert(from:in:)` or `shouldUpdate(from:in:)`. Return `nil` to skip importing from `source`. Note that throwing from this method will cause subsequent imports that are part of the same `importUniqueObjects(:sourceArray:)` call to be cancelled.
@@ -140,10 +140,10 @@ public extension ImportableUniqueObject {
     
     static func shouldInsert(from source: ImportSource, in transaction: BaseDataTransaction) -> Bool {
         
-        return Self.shouldUpdate(from: source, in: transaction)
+        return true
     }
     
-    static func shouldUpdate(from source: ImportSource, in transaction: BaseDataTransaction) -> Bool{
+    func shouldUpdate(from source: ImportSource, in transaction: BaseDataTransaction) -> Bool{
         
         return true
     }
@@ -163,7 +163,7 @@ public extension ImportableUniqueObject {
     
     static func shouldUpdateFromImportSource(_ source: ImportSource, inTransaction transaction: BaseDataTransaction) -> Bool {
         
-        return Self.shouldUpdate(from: source, in: transaction)
+        return true
     }
     
     static func uniqueIDFromImportSource(_ source: ImportSource, inTransaction transaction: BaseDataTransaction) throws -> UniqueIDType? {


### PR DESCRIPTION
This allows the user not to fetch the object again to check if it should be updated.