### PR TITLE
Get rid of `unsafeBitCast(_:to:)​​​`.

### DIFF
--- a/Sources/Internal/CoreStoreFetchRequest+CoreStore.swift
+++ b/Sources/Internal/CoreStoreFetchRequest+CoreStore.swift
@@ -36,6 +36,6 @@ internal extension CoreStoreFetchRequest {
     @nonobjc
     internal func dynamicCast<U: NSFetchRequestResult>() -> NSFetchRequest<U> {
         
-        return unsafeBitCast(self, to: NSFetchRequest<U>.self)
+        return unsafeDowncast(self, to: NSFetchRequest<U>.self)
     }
 }

--- a/Sources/Internal/CoreStoreFetchedResultsController.swift
+++ b/Sources/Internal/CoreStoreFetchedResultsController.swift
@@ -101,7 +101,7 @@ internal final class CoreStoreFetchedResultsController: NSFetchedResultsControll
     @nonobjc
     internal func dynamicCast<U: NSFetchRequestResult>() -> NSFetchedResultsController<U> {
         
-        return unsafeBitCast(self, to: NSFetchedResultsController<U>.self)
+        return unsafeDowncast(self, to: NSFetchedResultsController<U>.self)
     }
     
     deinit {

--- a/Sources/Observing/ListMonitor.swift
+++ b/Sources/Observing/ListMonitor.swift
@@ -677,7 +677,7 @@ public final class ListMonitor<T: NSManagedObject>: Hashable {
     
     internal func downcast() -> ListMonitor<NSManagedObject> {
         
-        return unsafeBitCast(self, to: ListMonitor<NSManagedObject>.self)
+        return self as Any as! ListMonitor<NSManagedObject>
     }
     
     internal func registerChangeNotification(_ notificationKey: UnsafeRawPointer, name: Notification.Name, toObserver observer: AnyObject, callback: @escaping (_ monitor: ListMonitor<T>) -> Void) {

--- a/Sources/Observing/ObjectMonitor.swift
+++ b/Sources/Observing/ObjectMonitor.swift
@@ -212,7 +212,7 @@ public final class ObjectMonitor<EntityType: NSManagedObject>: Equatable {
     
     internal func downcast() -> ObjectMonitor<NSManagedObject> {
         
-        return unsafeBitCast(self, to: ObjectMonitor<NSManagedObject>.self)
+        return self as Any as! ObjectMonitor<NSManagedObject>
     }
     
     deinit {


### PR DESCRIPTION
To perform a reference cast, use the casting operators (`as`, `as!`, or `as?`) or the `unsafe​Downcast(_:​to:​)` function. Do not use `unsafe​Bit​Cast(_:​to:​)` with class or pointer types; doing so may introduce undefined behavior.

https://developer.apple.com/reference/swift/1641250-unsafebitcast