### PR TITLE
Use `dynamicCast()` to cast `fetchedObjects` to `[T]?` without checking the type.

### DIFF
--- a/Sources/Observing/ListMonitor.swift
+++ b/Sources/Observing/ListMonitor.swift
@@ -202,7 +202,7 @@ public final class ListMonitor<T: NSManagedObject>: Hashable {
             !self.isPendingRefetch || Thread.isMainThread,
             "Attempted to access a \(cs_typeName(self)) outside the main thread while a refetch is in progress."
         )
-        return (self.fetchedResultsController.fetchedObjects as? [T]) ?? []
+        return self.fetchedResultsController.dynamicCast().fetchedObjects ?? []
     }
     
     /**
@@ -371,7 +371,7 @@ public final class ListMonitor<T: NSManagedObject>: Hashable {
             !self.isPendingRefetch || Thread.isMainThread,
             "Attempted to access a \(cs_typeName(self)) outside the main thread while a refetch is in progress."
         )
-        return (self.fetchedResultsController.fetchedObjects as? [T] ?? []).index(of: object)
+        return (self.fetchedResultsController.dynamicCast().fetchedObjects ?? []).index(of: object)
     }
     
     /**


### PR DESCRIPTION
Type checking takes a time. So there is a performance problem when casting a large number of fetched objects to an array of a certain type using the operator `as?`.