### PR TITLE
Corrected type-checking in fetchExisting to preserve input type

### DIFF
--- a/Sources/NSManagedObjectContext+Querying.swift
+++ b/Sources/NSManagedObjectContext+Querying.swift
@@ -62,7 +62,9 @@ extension NSManagedObjectContext: FetchableSource, QueryableSource {
                 
                 return object
             }
-            return T.cs_fromRaw(object: existingRawObject)
+            
+            let objectDynamicType = type(of: object)
+            return objectDynamicType.cs_fromRaw(object: existingRawObject)
         }
         catch {
             


### PR DESCRIPTION
Turns out the problem in #190 was very simple to fix- instead of using T, the type of the object passed to fetchExisting, use type(of:) to get the dynamic type at runtime and properly instantiate the result. The change shouldn't affect any existing projects that use the method since the return type is unchanged.