### PR TITLE
Changin internal transactionQueue to open

### DIFF
--- a/Sources/BaseDataTransaction.swift
+++ b/Sources/BaseDataTransaction.swift
@@ -402,7 +402,7 @@ public /*abstract*/ class BaseDataTransaction {
     // MARK: Internal
     
     internal let context: NSManagedObjectContext
-    internal let transactionQueue: DispatchQueue
+    open let transactionQueue: DispatchQueue
     internal let childTransactionQueue = DispatchQueue.serial("com.corestore.datastack.childTransactionQueue")
     internal let supportsUndo: Bool
     internal let bypassesQueueing: Bool


### PR DESCRIPTION
I changed the property transactionQueue in BaseDataTransaction from internal to open. This way it will be available outside the framework and can be later passed to the Alamofire completionQueue. This will make possible to use asynchronous transactions in the Alamofire completion closures.