### PR TITLE
Swift 4.1, Xcode 9.3 warnings fixed

### DIFF
--- a/Sources/AsynchronousDataTransaction.swift
+++ b/Sources/AsynchronousDataTransaction.swift
@@ -172,7 +172,7 @@ public final class AsynchronousDataTransaction: BaseDataTransaction {
             "Attempted to delete an entities from an already committed \(cs_typeName(self))."
         )
         
-        super.delete(([object1, object2] + objects).flatMap { $0 })
+        super.delete(([object1, object2] + objects).compactMap { $0 })
     }
     
     /**

--- a/Sources/AttributeProtocol.swift
+++ b/Sources/AttributeProtocol.swift
@@ -41,7 +41,7 @@ internal protocol AttributeProtocol: class {
     var renamingIdentifier: () -> String? { get }
     var defaultValue: () -> Any? { get }
     var affectedByKeyPaths: () -> Set<String> { get }
-    weak var parentObject: CoreStoreObject? { get set }
+    var parentObject: CoreStoreObject? { get set }
     var getter: CoreStoreManagedObject.CustomGetter? { get }
     var setter: CoreStoreManagedObject.CustomSetter? { get }
 }

--- a/Sources/BaseDataTransaction+Importing.swift
+++ b/Sources/BaseDataTransaction+Importing.swift
@@ -108,7 +108,7 @@ public extension BaseDataTransaction {
             
             return try autoreleasepool {
                 
-                return try sourceArray.flatMap { (source) -> D? in
+                return try sourceArray.compactMap { (source) -> D? in
                   
                     let entityType = into.entityClass 
                     guard entityType.shouldInsert(from: source, in: self) else {
@@ -201,7 +201,7 @@ public extension BaseDataTransaction {
                 var importSourceByID = Dictionary<D.UniqueIDType, D.ImportSource>()
                 let sortedIDs = try autoreleasepool {
                   
-                    return try sourceArray.flatMap { (source) -> D.UniqueIDType? in
+                    return try sourceArray.compactMap { (source) -> D.UniqueIDType? in
                         
                         guard let uniqueIDValue = try entityType.uniqueID(from: source, in: self) else {
                             

--- a/Sources/BaseDataTransaction.swift
+++ b/Sources/BaseDataTransaction.swift
@@ -181,7 +181,7 @@ public /*abstract*/ class BaseDataTransaction {
      */
     public func delete<D: DynamicObject>(_ object1: D?, _ object2: D?, _ objects: D?...) {
         
-        self.delete(([object1, object2] + objects).flatMap { $0 })
+        self.delete(([object1, object2] + objects).compactMap { $0 })
     }
     
     /**
@@ -230,7 +230,7 @@ public /*abstract*/ class BaseDataTransaction {
             !self.isCommitted,
             "Attempted to access inserted objects from an already committed \(cs_typeName(self))."
         )
-        return Set(self.context.insertedObjects.flatMap({ entity.cs_matches(object: $0) ? entity.cs_fromRaw(object: $0) : nil }))
+        return Set(self.context.insertedObjects.compactMap({ entity.cs_matches(object: $0) ? entity.cs_fromRaw(object: $0) : nil }))
     }
     
     /**
@@ -267,7 +267,7 @@ public /*abstract*/ class BaseDataTransaction {
             !self.isCommitted,
             "Attempted to access inserted objects IDs from an already committed \(cs_typeName(self))."
         )
-        return Set(self.context.insertedObjects.flatMap({ entity.cs_matches(object: $0) ? $0.objectID : nil }))
+        return Set(self.context.insertedObjects.compactMap({ entity.cs_matches(object: $0) ? $0.objectID : nil }))
     }
     
     /**
@@ -286,7 +286,7 @@ public /*abstract*/ class BaseDataTransaction {
             !self.isCommitted,
             "Attempted to access updated objects from an already committed \(cs_typeName(self))."
         )
-        return Set(self.context.updatedObjects.flatMap({ entity.cs_matches(object: $0) ? entity.cs_fromRaw(object: $0) : nil }))
+        return Set(self.context.updatedObjects.compactMap({ entity.cs_matches(object: $0) ? entity.cs_fromRaw(object: $0) : nil }))
     }
     
     /**
@@ -323,7 +323,7 @@ public /*abstract*/ class BaseDataTransaction {
             !self.isCommitted,
             "Attempted to access updated object IDs from an already committed \(cs_typeName(self))."
         )
-        return Set(self.context.updatedObjects.flatMap({ entity.cs_matches(object: $0) ? $0.objectID : nil }))
+        return Set(self.context.updatedObjects.compactMap({ entity.cs_matches(object: $0) ? $0.objectID : nil }))
     }
     
     /**
@@ -342,7 +342,7 @@ public /*abstract*/ class BaseDataTransaction {
             !self.isCommitted,
             "Attempted to access deleted objects from an already committed \(cs_typeName(self))."
         )
-        return Set(self.context.deletedObjects.flatMap({ entity.cs_matches(object: $0) ? entity.cs_fromRaw(object: $0) : nil }))
+        return Set(self.context.deletedObjects.compactMap({ entity.cs_matches(object: $0) ? entity.cs_fromRaw(object: $0) : nil }))
     }
     
     /**
@@ -380,7 +380,7 @@ public /*abstract*/ class BaseDataTransaction {
             !self.isCommitted,
             "Attempted to access deleted object IDs from an already committed \(cs_typeName(self))."
         )
-        return Set(self.context.deletedObjects.flatMap({ entity.cs_matches(object: $0) ? $0.objectID : nil }))
+        return Set(self.context.deletedObjects.compactMap({ entity.cs_matches(object: $0) ? $0.objectID : nil }))
     }
     
     

--- a/Sources/CustomSchemaMappingProvider.swift
+++ b/Sources/CustomSchemaMappingProvider.swift
@@ -56,8 +56,8 @@ public class CustomSchemaMappingProvider: Hashable, SchemaMappingProvider {
         CoreStore.assert(
             cs_lazy {
                 
-                let sources = entityMappings.flatMap({ $0.entityMappingSourceEntity })
-                let destinations = entityMappings.flatMap({ $0.entityMappingDestinationEntity })
+                let sources = entityMappings.compactMap({ $0.entityMappingSourceEntity })
+                let destinations = entityMappings.compactMap({ $0.entityMappingDestinationEntity })
                 return sources.count == Set(sources).count
                     && destinations.count == Set(destinations).count
             },

--- a/Sources/NSManagedObjectContext+Querying.swift
+++ b/Sources/NSManagedObjectContext+Querying.swift
@@ -91,13 +91,13 @@ extension NSManagedObjectContext: FetchableSource, QueryableSource {
     @nonobjc
     public func fetchExisting<D: DynamicObject, S: Sequence>(_ objects: S) -> [D] where S.Iterator.Element == D {
         
-        return objects.flatMap({ self.fetchExisting($0.cs_id()) })
+        return objects.compactMap({ self.fetchExisting($0.cs_id()) })
     }
     
     @nonobjc
     public func fetchExisting<D: DynamicObject, S: Sequence>(_ objectIDs: S) -> [D] where S.Iterator.Element == NSManagedObjectID {
         
-        return objectIDs.flatMap({ self.fetchExisting($0) })
+        return objectIDs.compactMap({ self.fetchExisting($0) })
     }
     
     @nonobjc

--- a/Sources/Relationship.swift
+++ b/Sources/Relationship.swift
@@ -1071,7 +1071,7 @@ extension RelationshipContainer.ToManyOrdered {
         
         return relationship.nativeValue.elementsEqual(
             collection.lazy.map({ $0.rawObject! }),
-            by: { ($0 as! NSManagedObject) == ($1 as! NSManagedObject) }
+            by: { ($0 as! NSManagedObject) == ($1 as NSManagedObject) }
         )
     }
     
@@ -1089,7 +1089,7 @@ extension RelationshipContainer.ToManyOrdered {
         
         return relationship.nativeValue.elementsEqual(
             collection.lazy.map({ $0.rawObject! }),
-            by: { ($0 as! NSManagedObject) == ($1 as! NSManagedObject) }
+            by: { ($0 as! NSManagedObject) == ($1 as NSManagedObject) }
         )
     }
     

--- a/Sources/RelationshipProtocol.swift
+++ b/Sources/RelationshipProtocol.swift
@@ -37,7 +37,7 @@ internal protocol RelationshipProtocol: class {
     var deleteRule: NSDeleteRule { get }
     var inverse: (type: CoreStoreObject.Type, keyPath: () -> KeyPathString?) { get }
     var affectedByKeyPaths: () -> Set<String> { get }
-    weak var parentObject: CoreStoreObject? { get set }
+    var parentObject: CoreStoreObject? { get set }
     var versionHashModifier: () -> String? { get }
     var renamingIdentifier: () -> String? { get }
     var minCount: Int { get }

--- a/Sources/SynchronousDataTransaction.swift
+++ b/Sources/SynchronousDataTransaction.swift
@@ -127,7 +127,7 @@ public final class SynchronousDataTransaction: BaseDataTransaction {
             "Attempted to delete an entities from an already committed \(cs_typeName(self))."
         )
         
-        super.delete(([object1, object2] + objects).flatMap { $0 })
+        super.delete(([object1, object2] + objects).compactMap { $0 })
     }
     
     /**


### PR DESCRIPTION
I tried to remove some warnings appears after update Xcode to 9.3

1. Swift 4.1 New: flatMap function replaced with compactMap
2. Protocol description deny using weak statement in property declaration
3. Cast warning from CoreStoreManagedObject to NSManagedObject