### PR TITLE
[ListMonitor] Fix performance of `subscript(safeSectionIndex:safeItemIndex:)`.

### DIFF
--- a/Sources/ListMonitor.swift
+++ b/Sources/ListMonitor.swift
@@ -144,7 +144,7 @@ public final class ListMonitor<D: DynamicObject>: Hashable {
             
             return nil
         }
-        return ObjectType.cs_fromRaw(object: section.objects![itemIndex] as! NSManagedObject)
+        return self[IndexPath(indexes: [sectionIndex, itemIndex])]
     }
     
     /**


### PR DESCRIPTION
There is a performance problem in Swift when getting an object from the Objective-C array with a large number of objects using subscript. It requires casting the array between Objective-C and Swift, that is pretty slow.