### PR TITLE
[ListMonitor] Fix performance of `numberOfObjects()`.

### DIFF
--- a/Sources/ListMonitor.swift
+++ b/Sources/ListMonitor.swift
@@ -232,10 +232,7 @@ public final class ListMonitor<D: DynamicObject>: Hashable {
             !self.isPendingRefetch || Thread.isMainThread,
             "Attempted to access a \(cs_typeName(self)) outside the main thread while a refetch is in progress."
         )
-        return self.sections().reduce(0, { (numberOfObjects, sectionInfo) -> Int in
-            
-            return numberOfObjects + sectionInfo.numberOfObjects
-        })
+        return (self.fetchedResultsController.fetchedObjects as NSArray?)?.count ?? 0
     }
     
     /**

--- a/Sources/ListMonitor.swift
+++ b/Sources/ListMonitor.swift
@@ -232,7 +232,10 @@ public final class ListMonitor<D: DynamicObject>: Hashable {
             !self.isPendingRefetch || Thread.isMainThread,
             "Attempted to access a \(cs_typeName(self)) outside the main thread while a refetch is in progress."
         )
-        return self.fetchedResultsController.fetchedObjects?.count ?? 0
+        return self.sections().reduce(0, { (numberOfObjects, sectionInfo) -> Int in
+            
+            return numberOfObjects + sectionInfo.numberOfObjects
+        })
     }
     
     /**


### PR DESCRIPTION
There is a performance problem in Swift when calling `count` method on an array with a large number of fetched objects. It requires casting the array between Objective-C and Swift, that is pretty slow.