### PR TITLE
Fixes #328 by specifying platform requirements in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,9 @@ import PackageDescription
 
 let package = Package(
     name: "CoreStore",
+    platforms: [
+           .macOS(.v10_12), .iOS(.v10), .tvOS(.v10), .watchOS(.v3)
+    ],
     products: [
         .library(name: "CoreStore", type: .static, targets: ["CoreStore"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 //
 //  Package.swift
 //  CoreStore


### PR DESCRIPTION
The platform specification was introduced in SPM description 5.0.