### PR TITLE
Fix for build on iOS with Swift Package Manager

### DIFF
--- a/Sources/CoreStore+CustomDebugStringConvertible.swift
+++ b/Sources/CoreStore+CustomDebugStringConvertible.swift
@@ -1204,7 +1204,7 @@ extension NSEntityDescription: CoreStoreDebugStringConvertible {
             
             info.append(("compoundIndexes", self.compoundIndexes))
         }
-        if #available(macOS 10.11, *) {
+        if #available(macOS 10.11, iOS 9.0, *) {
             
             info.append(("uniquenessConstraints", self.uniquenessConstraints))
         }

--- a/Sources/CoreStoreSchema.swift
+++ b/Sources/CoreStoreSchema.swift
@@ -451,7 +451,7 @@ public final class CoreStoreSchema: DynamicSchema {
         }
         for (entity, entityDescription) in entityDescriptionsByEntity {
 
-            if #available(macOS 10.11, *) {
+            if #available(macOS 10.11, iOS 9.0, *) {
                 
                 let uniqueConstraints = entity.uniqueConstraints.filter({ !$0.isEmpty })
                 if !uniqueConstraints.isEmpty {

--- a/Sources/DataStack+Migration.swift
+++ b/Sources/DataStack+Migration.swift
@@ -750,7 +750,7 @@ extension DataStack {
         }
         let fileManager = FileManager.default
         let systemTemporaryDirectoryURL: URL
-        if #available(macOS 10.12, *) {
+        if #available(macOS 10.12, iOS 10.0, *) {
 
             systemTemporaryDirectoryURL = fileManager.temporaryDirectory
         }


### PR DESCRIPTION
CoreStore does not build for iOS if it was added by Swift Package Manager, because of version restrictions.