### PR TITLE
Allow nil default values for stored attributes

### DIFF
--- a/Sources/Field.Stored.swift
+++ b/Sources/Field.Stored.swift
@@ -68,7 +68,7 @@ extension FieldContainer {
          - parameter affectedByKeyPaths: a set of key paths for properties whose values affect the value of the receiver. This is similar to `NSManagedObject.keyPathsForValuesAffectingValue(forKey:)`.
          */
         public init(
-            wrappedValue initial: @autoclosure @escaping () -> V,
+            wrappedValue initial: @autoclosure @escaping () -> V?,
             _ keyPath: KeyPathString,
             versionHashModifier: @autoclosure @escaping () -> String? = nil,
             previousVersionKeyPath: @autoclosure @escaping () -> String? = nil,
@@ -87,6 +87,28 @@ extension FieldContainer {
                 customSetter: customSetter,
                 affectedByKeyPaths: affectedByKeyPaths
             )
+        }
+
+        public init(
+          wrappedValue initial: @autoclosure @escaping () -> V,
+          _ keyPath: KeyPathString,
+          versionHashModifier: @autoclosure @escaping () -> String? = nil,
+          previousVersionKeyPath: @autoclosure @escaping () -> String? = nil,
+          customGetter: ((_ object: ObjectProxy<O>, _ field: ObjectProxy<O>.FieldProxy<V>) -> V)? = nil,
+          customSetter: ((_ object: ObjectProxy<O>, _ field: ObjectProxy<O>.FieldProxy<V>, _ newValue: V) -> Void)? = nil,
+          affectedByKeyPaths: @autoclosure @escaping () -> Set<KeyPathString> = []
+        ) {
+
+          self.init(
+            wrappedValue: initial,
+            keyPath: keyPath,
+            isOptional: false,
+            versionHashModifier: versionHashModifier,
+            renamingIdentifier: previousVersionKeyPath,
+            customGetter: customGetter,
+            customSetter: customSetter,
+            affectedByKeyPaths: affectedByKeyPaths
+          )
         }
 
 
@@ -267,7 +289,7 @@ extension FieldContainer {
         // MARK: FilePrivate
 
         fileprivate init(
-            wrappedValue initial: @escaping () -> V,
+            wrappedValue initial: @escaping () -> V?,
             keyPath: KeyPathString,
             isOptional: Bool,
             versionHashModifier: @escaping () -> String?,


### PR DESCRIPTION
Core Data does not require default values for attributes. For the sake of model compatibility, CoreStore should not either.
This change is purely additive: it allows nil values to be (explicitly) provided as the initial value of properties wrapped with Field.Stored.

In theory, the only thing necessary to make this change is allowing an optional `wrappedValue`. In practice, that seems to produce an uncaught compilation error if you use assignment syntax to initialize a wrapped value with a non-`nil` value.

This change should increment the minor version number.