### PR TITLE
Fix compound indexes for dynamic models

### DIFF
--- a/CoreStoreTests/DynamicModelTests.swift
+++ b/CoreStoreTests/DynamicModelTests.swift
@@ -197,7 +197,7 @@ class DynamicModelTests: BaseTestDataTestCase {
                 modelVersion: "V1",
                 entities: [
                     Entity<Animal>("Animal"),
-                    Entity<Dog>("Dog"),
+                    Entity<Dog>("Dog", indexes: [[\Dog.$nickname, \Dog.$age]]),
                     Entity<Person>("Person")
                 ],
                 versionLock: [

--- a/Sources/CoreStoreSchema.swift
+++ b/Sources/CoreStoreSchema.swift
@@ -585,7 +585,7 @@ public final class CoreStoreSchema: DynamicSchema {
             entityDescription.indexes = entity.indexes.map { (compoundIndexes) in
                 
                 return NSFetchIndexDescription.init(
-                    name: "_CoreStoreSchema_indexes_\(entityDescription.name!)_\(compoundIndexes.joined(separator: "-"))",
+                    name: "_CoreStoreSchema_indexes_\(entityDescription.name!)_\(compoundIndexes.joined(separator: "_"))",
                     elements: compoundIndexes.map { (keyPath) in
                         
                         return NSFetchIndexElementDescription(


### PR DESCRIPTION
Right now if you try to create any compound index for core store dynamic model you will receive syntax error. This because "-" is prohibited and caused syntax error. For instance, for `Dog` model in `DynamicModelTests.swift` you will receive this error:

```
near "-": syntax error in "CREATE INDEX IF NOT EXISTS Z_Dog__CoreStoreSchema_indexes_Dog_age-nickname ON ZANIMAL (ZAGE COLLATE BINARY ASC, ZNICKNAME COLLATE BINARY ASC)
```

Let's use "_" instead.