### PR TITLE
Fix SPM install + Add secure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 //
 //  Package.swift
 //  CoreStore
@@ -40,7 +40,7 @@ let package = Package(
             name: "CoreStore",
             dependencies: [],
             path: "Sources",
-            exclude: ["CoreStoreBridge.h", "CoreStoreBridge.m"]
+            exclude: ["CoreStoreBridge.h", "CoreStoreBridge.m", "ObjectPublisher+Rective.swift"]
         ),
         .testTarget(
             name: "CoreStoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
             name: "CoreStore",
             dependencies: [],
             path: "Sources",
-            exclude: ["CoreStoreBridge.h", "CoreStoreBridge.m", "ObjectPublisher+Reactive.swift"]
+            exclude: ["CoreStoreBridge.h", "CoreStoreBridge.m", "ObjectPublisher+Reactive.swift", "Info.plist"]
         ),
         .testTarget(
             name: "CoreStoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
             name: "CoreStore",
             dependencies: [],
             path: "Sources",
-            exclude: ["CoreStoreBridge.h", "CoreStoreBridge.m", "ObjectPublisher+Rective.swift"]
+            exclude: ["CoreStoreBridge.h", "CoreStoreBridge.m", "ObjectPublisher+Reactive.swift"]
         ),
         .testTarget(
             name: "CoreStoreTests",

--- a/Sources/SQLiteStore.swift
+++ b/Sources/SQLiteStore.swift
@@ -247,7 +247,7 @@ public final class SQLiteStore: LocalStorage {
             do {
                 
                 let trashURL = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!)
-                    .appendingPathComponent(BundlstoreOptionse.main.bundleIdentifier ?? "com.CoreStore.DataStack", isDirectory: true)
+                    .appendingPathComponent(Bundle.main.bundleIdentifier ?? "com.CoreStore.DataStack", isDirectory: true)
                     .appendingPathComponent("trash", isDirectory: true)
                 try fileManager.createDirectory(
                     at: trashURL,

--- a/Sources/SQLiteStore.swift
+++ b/Sources/SQLiteStore.swift
@@ -74,12 +74,13 @@ public final class SQLiteStore: LocalStorage {
      
      - Warning: The default SQLite file location for the `LegacySQLiteStore` and `SQLiteStore` are different. If the app was depending on CoreStore's default directories prior to 2.0.0, make sure to use the `SQLiteStore.legacy(...)` factory methods to create the `SQLiteStore` instead of using initializers directly.
      */
-    public init() {
+    public init(secure: Bool = false) {
         
         self.fileURL = SQLiteStore.defaultFileURL
         self.configuration = nil
         self.migrationMappingProviders = []
         self.localStorageOptions = nil
+        self.secure = secure
     }
     
     /**
@@ -133,7 +134,8 @@ public final class SQLiteStore: LocalStorage {
     
     
     // MARK: StorageInterface
-    
+    private let secure: Bool = false  
+ 
     /**
      The string identifier for the `NSPersistentStore`'s `type` property. For `SQLiteStore`s, this is always set to `NSSQLiteStoreType`.
      */
@@ -217,6 +219,9 @@ public final class SQLiteStore: LocalStorage {
             
             var storeOptions = self.storeOptions ?? [:]
             storeOptions[NSSQLitePragmasOption] = ["journal_mode": "DELETE"]
+            if secure {
+               storeOptions[NSPersistentStoreFileProtectionKey] = FileProtectionType.complete
+            }
             try coordinator.addPersistentStore(
                 ofType: Self.storeType,
                 configurationName: self.configuration,
@@ -242,7 +247,7 @@ public final class SQLiteStore: LocalStorage {
             do {
                 
                 let trashURL = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!)
-                    .appendingPathComponent(Bundle.main.bundleIdentifier ?? "com.CoreStore.DataStack", isDirectory: true)
+                    .appendingPathComponent(BundlstoreOptionse.main.bundleIdentifier ?? "com.CoreStore.DataStack", isDirectory: true)
                     .appendingPathComponent("trash", isDirectory: true)
                 try fileManager.createDirectory(
                     at: trashURL,

--- a/Sources/SQLiteStore.swift
+++ b/Sources/SQLiteStore.swift
@@ -134,7 +134,7 @@ public final class SQLiteStore: LocalStorage {
     
     
     // MARK: StorageInterface
-    private let secure: Bool = false  
+    private var secure: Bool = false  
  
     /**
      The string identifier for the `NSPersistentStore`'s `type` property. For `SQLiteStore`s, this is always set to `NSSQLiteStoreType`.


### PR DESCRIPTION
This PR aims to fix one issue for SPM install:

- fix warning for Info.plist as unhandled resource
- remove the Combine extension because raise error and make the lib not working at all

Also it introduces and extra init param that will force the sqlite file to be encrypted ( I took as reference #145 )