### PR TITLE
Add a Back to Top Button in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a id="top"></a>
 <p align="center">
 <img alt="CoreStore" src="https://github.com/JohnEstropia/CoreStore/raw/develop/CoreStore.png" width=614 />
 <br />
@@ -2510,3 +2511,5 @@ I'd love to hear about apps using CoreStore. Send me a message and I'll welcome 
 # License
 CoreStore is released under an MIT license. See the [LICENSE](https://raw.githubusercontent.com/JohnEstropia/CoreStore/master/LICENSE) file for more information
 
+---
+[⬆️ Back to top](#top)


### PR DESCRIPTION
I noticed that the Readme is incredibly long and hard to jump back up to the top from the bottom. So I added a button for it.