### PR TITLE
issue #504 | Crash when printing model schema, if one of the attribut…

### DIFF
--- a/Sources/DynamicSchema+Convenience.swift
+++ b/Sources/DynamicSchema+Convenience.swift
@@ -184,6 +184,14 @@ extension DynamicSchema {
                             valueTypeString += "?"
                             defaultString = " = nil"
                         }
+                    case .URIAttributeType:
+                        valueTypeString = String(describing: URL.self)
+                        if let defaultValue = (attribute.defaultValue as! URL.QueryableNativeType?).flatMap(URL.cs_fromQueryableNativeType) {
+                            defaultString = " = \"\(defaultValue.absoluteString)\""
+                        } else if attribute.isOptional {
+                            valueTypeString += "?"
+                            defaultString = " = nil"
+                        }
                     case .binaryDataAttributeType:
                         valueTypeString = String(describing: Data.self)
                         if let defaultValue = (attribute.defaultValue as! Data.QueryableNativeType?).flatMap(Data.cs_fromQueryableNativeType) {


### PR DESCRIPTION
Added a missing .URIAttributeType case so that it won't go to default, causing fatalError