### PR TITLE
issue #509 | Xcode 16.0 beta 6 error - "'CATransaction' is unavailable in watchOS"

### DIFF
--- a/Sources/Internals.DiffableDataUIDispatcher.swift
+++ b/Sources/Internals.DiffableDataUIDispatcher.swift
@@ -107,17 +107,17 @@ extension Internals {
                 }
 
                 #if canImport(QuartzCore)
-
-                CATransaction.begin()
-
-                if !animatingDifferences {
-
-                    CATransaction.setDisableActions(true)
-                }
-                performDiffingUpdates()
-
-                CATransaction.commit()
-
+//
+//                CATransaction.begin()
+//
+//                if !animatingDifferences {
+//
+//                    CATransaction.setDisableActions(true)
+//                }
+//                performDiffingUpdates()
+//
+//                CATransaction.commit()
+//
                 #else
 
                 performDiffingUpdates()

--- a/Sources/Internals.DiffableDataUIDispatcher.swift
+++ b/Sources/Internals.DiffableDataUIDispatcher.swift
@@ -106,21 +106,21 @@ extension Internals {
                     }
                 }
 
-                #if os(iOS)
+                #if os(watchOS)
                 
-                CATransaction.begin()
-
-                if !animatingDifferences {
-
-                    CATransaction.setDisableActions(true)
-                }
                 performDiffingUpdates()
-
-                CATransaction.commit()
 
                 #else
 
+                CATransaction.begin()
+                
+                if !animatingDifferences {
+                    
+                    CATransaction.setDisableActions(true)
+                }
                 performDiffingUpdates()
+                
+                CATransaction.commit()
 
 
                 #endif

--- a/Sources/Internals.DiffableDataUIDispatcher.swift
+++ b/Sources/Internals.DiffableDataUIDispatcher.swift
@@ -106,18 +106,18 @@ extension Internals {
                     }
                 }
 
-                #if canImport(QuartzCore)
-//
-//                CATransaction.begin()
-//
-//                if !animatingDifferences {
-//
-//                    CATransaction.setDisableActions(true)
-//                }
-//                performDiffingUpdates()
-//
-//                CATransaction.commit()
-//
+                #if os(iOS)
+                
+                CATransaction.begin()
+
+                if !animatingDifferences {
+
+                    CATransaction.setDisableActions(true)
+                }
+                performDiffingUpdates()
+
+                CATransaction.commit()
+
                 #else
 
                 performDiffingUpdates()


### PR DESCRIPTION
A fix to the following issue:
[I'm experiencing issues when trying to build the project using the latest Xcode 16.0 beta 6 (16A5230g).
The error appears in the Internals.DiffableDataUIDispatcher.swift file. See image below. Have anyone else experienced this issue? It worked perfectly in the Xcode 15.4.](https://github.com/JohnEstropia/CoreStore/issues/509)

The error is caused by the CA Transaction not being available for iOS. This is fixed by having the iOS os flag

![360338259-5735e15d-cb78-4a6c-a247-78894ad810b8-2](https://github.com/user-attachments/assets/e1e455e9-7a40-46eb-8ff7-58ab77d6a729)
